### PR TITLE
clarify leafnodes

### DIFF
--- a/leafnodes/leafnode_conf.md
+++ b/leafnodes/leafnode_conf.md
@@ -1,28 +1,27 @@
-## `LeafNode` Configuration Block
+## `leafnodes` Configuration Block
 
 | Property | Description |
 | :------  | :---- |
 | `advertise` | Hostport `<host>:<port>` to advertise to other gateways. |
 | `authorization` | Authorization block (same as other nats-server `authorization` configuration). |
-| `host` | Interface where the gateway will listen for incomming gateway connections. |
+| `host` | Interface where the gateway will listen for incoming leafnode connections. |
 | `listen` | Combines `host` and `port` as `<host>:<port>` |
-| `name` | Name for this cluster, all gateways belonging to the same cluster, should specify the same name. |
 | `no_advertise` | if `true` the leafnode shouldn't be advertised. |
-| `port` | Port where the gateway will listen for incomming gateway connections. |
+| `port` | Port where the leafnode will listen for incoming leafnode connections. |
 | `remotes` | List of `remote` entries specifying servers where leafnode client connection can be made. |
 | `tls` | TLS configuration block (same as other nats-server `tls` configuration). |
 
 
-### LeafNode `Remote` Entry Block
+### LeafNode `remotes` Entry Block
 
 | Property | Description |
 | :------  | :---- |
-| `url` | Leafnode URL (URL protocol should be `leafnode`). |
+| `url` | Leafnode URL (URL protocol should be `nats-leaf`). |
 | `account` | Account public key identifying the leafnode. Account must be defined locally. |
 | `credentials` | Credential file for connecting to the leafnode server. |
-| `tls` | A TLS configuration block. Gateway client will use specified TLS certificates when connecting/authenticating. |
+| `tls` | A TLS configuration block. Leafnode client will use specified TLS certificates when connecting/authenticating. |
 
-### `TLS` Configuration Block
+### `tls` Configuration Block
 
 | Property | Description |
 | :------  | :---- |

--- a/leafnodes/leafnode_conf.md
+++ b/leafnodes/leafnode_conf.md
@@ -2,12 +2,12 @@
 
 | Property | Description |
 | :------  | :---- |
-| `advertise` | Hostport `<host>:<port>` to advertise to other gateways. |
+| `advertise` | Hostport `<host>:<port>` to advertise to other servers. |
 | `authorization` | Authorization block (same as other nats-server `authorization` configuration). |
-| `host` | Interface where the gateway will listen for incoming leafnode connections. |
+| `host` | Interface where the server will listen for incoming leafnode connections. |
 | `listen` | Combines `host` and `port` as `<host>:<port>` |
 | `no_advertise` | if `true` the leafnode shouldn't be advertised. |
-| `port` | Port where the leafnode will listen for incoming leafnode connections. |
+| `port` | Port where the server will listen for incoming leafnode connections. |
 | `remotes` | List of `remote` entries specifying servers where leafnode client connection can be made. |
 | `tls` | TLS configuration block (same as other nats-server `tls` configuration). |
 


### PR DESCRIPTION
This corrects a few config item key names and shows the key names
as lowercase as they would appear in the actual config

Also use `nats-leaf` as shown in the tutorial section on leaf nodes

server.LeafNodeOpts has no `name` and I can't find it in parseLeafNodes