### PR TITLE
added global redirect

### DIFF
--- a/book.json
+++ b/book.json
@@ -9,7 +9,8 @@
     "include-html",
     "toggle-chapters",
     "anchors",
-    "edit-link"
+    "edit-link",
+    "redirect-sub@https://github.com/nats-io/gitbook-plugin-redirect-sub.git"
   ],
   "pluginsConfig": {
     "prism": {
@@ -22,6 +23,9 @@
       "base": "https://github.com/nats-io/docs/edit/master",
       "label": "edit"
 
+  },
+  "redirect_sub" : {
+      "root" : "https://docs.nats.io"
   }
   }
 }


### PR DESCRIPTION
uses a custom plugin to redirect all pages to the new docs, pages are not targeted, everything goes to root. Too many renames to handle all the special cases I think.